### PR TITLE
Restore Polish translation credits from GNOME

### DIFF
--- a/po/gnome-copyrights.txt
+++ b/po/gnome-copyrights.txt
@@ -712,14 +712,13 @@
 
 
 ========== pl.po ==========
-# Copyright (C) 2005-2006 Free Software Foundation, Inc.
-# -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
-# Aviary.pl
-# Jeśli masz jakiekolwiek uwagi odnoszące się do tłumaczenia lub chcesz
-# pomóc w jego rozwijaniu i pielęgnowaniu, napisz do nas:
-# gnomepl@aviary.pl
-# -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+# Polish translation for gnome-backgrounds.
+# Copyright © 2005-2008 the gnome-backgrounds authors.
+# This file is distributed under the same license as the gnome-backgrounds package.
+# Artur Flinta <aflinta@at.kernel.pl>, 2005-2006.
 # Piotr Zaryk <pzaryk@aviary.pl>, 2008.
+# Aviary.pl <gnomepl@aviary.pl>, 2008.
+#
 
 
 


### PR DESCRIPTION
This commit restores proper credits and copyrights for the Polish translation that were somehow lost during forking, using historical information from git.gnome.org.