### PR TITLE
use ninja dist for release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,9 +89,9 @@ after_scripts:
 releases:
   draft: false
   prerelease: false
-  checksum: true
+  checksum: false
   file_glob: true
-  files: mate-backgrounds-*.tar.xz
+  files: _build/meson-dist/mate-backgrounds-*.tar.xz*
   github_release:
     tags: true
     overwrite: true


### PR DESCRIPTION
If use ninja dist to create tarballs, they are:
```
$ ls _build/meson-dist/mate-backgrounds-*.tar.xz*
_build/meson-dist/mate-backgrounds-1.22.0.tar.xz
_build/meson-dist/mate-backgrounds-1.22.0.tar.xz.sha256sum
```