### PR TITLE
Fix the error if have a newer version of gettext.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,7 @@
 SUBDIRS = po abstract desktop nature
 
+ACLOCAL_AMFLAGS = -I m4 ${ACLOCAL_FLAGS}
+
 dist-hook:
 	@if test -d "$(srcdir)/.git"; \
 	then \


### PR DESCRIPTION
error: gettext infrastructure mismatch: using a Makefile.in.in
from gettext version 0.19 but the autoconf macros are from gettext
version 0.20

Fixes https://github.com/mate-desktop/mate-backgrounds/issues/26

Taken from https://github.com/mate-desktop/mate-themes/commit/fec8541547efb3e41d49f20ff2420e4e5cfdf54d
But i have no idea why this fixes the build issue :)
Failed build for f31 /rawhide:
https://copr.fedorainfracloud.org/coprs/raveit65/MATE-1.23.x/build/1027026/
Fixed build with that commit:
https://copr.fedorainfracloud.org/coprs/raveit65/MATE-1.23.x/build/1027423/