### PR TITLE
build: do not invoke AM_GNU_GETTEXT

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 AM_INIT_AUTOMAKE([1.9 no-dist-gzip dist-xz tar-ustar check-news])
 
 AM_GNU_GETTEXT_VERSION([0.19.8])
-AM_GNU_GETTEXT([external])
+AM_PO_SUBDIRS
 
 AM_MAINTAINER_MODE
 


### PR DESCRIPTION
mate-backgrounds does not link with anything, the only desired side
effect of AM_GNU_GETTEXT is AM_PO_SUBDIRS invocation. It fixes packages
built specifically without any arch specific pieces and therefore with
potentially unknown triplet like noarch-pld-linux.