### PR TITLE
build: do not install mo files (translations in xml files)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -18,6 +18,11 @@ dist-hook:
 		echo A git clone is required to generate a ChangeLog >&2; \
 	fi
 
+# we don't want to install mo files, all translations are already stored
+# in xml files
+install-data-local:
+	$(MAKE) -C po uninstall
+
 EXTRA_DIST = \
 	its \
 	autogen.sh \


### PR DESCRIPTION
The translation is loaded at 
https://github.com/mate-desktop/mate-control-center/blob/7cc14bf1a2f4a7a0dc6eaf2487348101fde19651/capplets/appearance/mate-wp-xml.c#L203