### PR TITLE
abstract: remove the size from the wallpaper name

### DIFF
--- a/abstract/mate-abstract.xml.in.in
+++ b/abstract/mate-abstract.xml.in.in
@@ -67,7 +67,7 @@
 		<artist>Wyng Stancikaite</artist>
 	</wallpaper>
 	<wallpaper deleted="false">
-		<name>Something slowly gets clear (3840x2160)</name>
+		<name>Something slowly gets clear</name>
 		<filename>@datadir@/backgrounds/mate/abstract/Elephants_3840x2160.jpg</filename>
 		<shade_type>vertical-gradient</shade_type>
 		<pcolor>#729FCF</pcolor>
@@ -76,7 +76,7 @@
 		<artist>Wyng Stancikaite</artist>
 	</wallpaper>
 	<wallpaper deleted="false">
-		<name>Something slowly gets clear (5640x3172)</name>
+		<name>Something slowly gets clear</name>
 		<filename>@datadir@/backgrounds/mate/abstract/Elephants_5640x3172.jpg</filename>
 		<shade_type>vertical-gradient</shade_type>
 		<pcolor>#729FCF</pcolor>


### PR DESCRIPTION
The wallpapers are sorted by using the description field, it's the tooltip text shown in mate-appearance-properties, which already includes the size. The wallpapers are stored in a hash table where the key is the filename.